### PR TITLE
Allow scraping Betano matches by identifier

### DIFF
--- a/src/main/java/com/example/demo/controller/BetanoScraperController.java
+++ b/src/main/java/com/example/demo/controller/BetanoScraperController.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -27,9 +28,9 @@ public class BetanoScraperController {
      * @return List of betting events with markets and selections
      */
     @GetMapping("/betano")
-    public ResponseEntity<List<BettingEvent>> scrapeBetano() {
-        log.info("Received request to scrape Betano");
-        List<BettingEvent> events = scraperService.scrapeBettingData();
+    public ResponseEntity<List<BettingEvent>> scrapeBetano(@RequestParam("matchId") String matchId) {
+        log.info("Received request to scrape Betano for match {}", matchId);
+        List<BettingEvent> events = scraperService.scrapeBettingData(matchId);
         log.info("Scraping completed, returning {} events", events.size());
         return ResponseEntity.ok(events);
     }

--- a/src/main/java/com/example/demo/scheduler/BetanoScraperScheduler.java
+++ b/src/main/java/com/example/demo/scheduler/BetanoScraperScheduler.java
@@ -33,6 +33,9 @@ public class BetanoScraperScheduler {
     
     @Value("${scraper.output.directory:./scraper-output}")
     private String outputDirectory;
+
+    @Value("${scraper.matchId:}")
+    private String matchId;
     
     /**
      * Runs the scraper every 45 seconds (configurable)
@@ -43,7 +46,7 @@ public class BetanoScraperScheduler {
         log.info("Starting scheduled scraping task");
         
         try {
-            List<BettingEvent> events = scraperService.scrapeBettingData();
+            List<BettingEvent> events = scraperService.scrapeBettingData(matchId);
             log.info("Scheduled scraping completed, found {} events", events.size());
             
             if (outputEnabled && !events.isEmpty()) {


### PR DESCRIPTION
## Summary
- accept `matchId` as a request parameter for Betano scraping
- build match specific URL and API filters in the scraper service
- filter parsed events and scheduler runs for the selected match

## Testing
- `bash gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_689e3377c0b48323bd85b3b20e089e4e