### PR TITLE
Map Betano fields and parse date format

### DIFF
--- a/src/main/java/com/example/demo/model/BettingEvent.java
+++ b/src/main/java/com/example/demo/model/BettingEvent.java
@@ -16,6 +16,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class BettingEvent {
+    private String eventId;
     private String matchName;
     private LocalDateTime startTime;
     private List<BettingMarket> markets;


### PR DESCRIPTION
## Summary
- Map Betano event, market and selection fields to model objects
- Add event ID to betting events and parse selection prices
- Parse Betano date strings with a matching DateTimeFormatter

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_689e33792de88323969f9ef5187ac8fc