### PR TITLE
Refine Betano API interception pattern

### DIFF
--- a/src/main/java/com/example/demo/service/BetanoScraperService.java
+++ b/src/main/java/com/example/demo/service/BetanoScraperService.java
@@ -59,8 +59,8 @@ public class BetanoScraperService {
             try (BrowserContext context = createBrowserContext(browser)) {
                 Page page = context.newPage();
 
-                // Set up request interception for XHR/JSON API requests related to the match
-                String apiPattern = ".*api.*" + (matchId != null ? matchId : "") + ".*";
+                // Set up request interception for Betano's betting API endpoints
+                String apiPattern = ".*/api/betting/.*" + (matchId != null ? Pattern.quote(matchId) + ".*" : "");
                 page.route(Pattern.compile(apiPattern), route -> {
                     log.debug("Intercepted API request: {}", route.request().url());
                     route.resume();


### PR DESCRIPTION
## Summary
- Narrow Playwright route interception to Betano's betting API endpoints

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_689e385fe67483239ddc16332834b8f6