### PR TITLE
Map Betano API fields and add parsing test

### DIFF
--- a/src/main/java/com/example/demo/model/BettingEvent.java
+++ b/src/main/java/com/example/demo/model/BettingEvent.java
@@ -16,6 +16,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class BettingEvent {
+    private String eventId;
     private String matchName;
     private LocalDateTime startTime;
     private List<BettingMarket> markets;

--- a/src/main/java/com/example/demo/model/BettingMarket.java
+++ b/src/main/java/com/example/demo/model/BettingMarket.java
@@ -15,6 +15,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class BettingMarket {
+    private String marketId;
     private String marketType;
     private List<BettingSelection> selections;
 }

--- a/src/main/java/com/example/demo/model/BettingSelection.java
+++ b/src/main/java/com/example/demo/model/BettingSelection.java
@@ -13,6 +13,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class BettingSelection {
+    private String selectionId;
     private String selectionName;
     private double odds;
 }

--- a/src/test/java/com/example/demo/service/BetanoScraperServiceTest.java
+++ b/src/test/java/com/example/demo/service/BetanoScraperServiceTest.java
@@ -1,0 +1,36 @@
+package com.example.demo.service;
+
+import com.example.demo.config.ProxyConfig;
+import com.example.demo.model.BettingEvent;
+import com.example.demo.util.UserAgentRotator;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BetanoScraperServiceTest {
+
+    @Test
+    void parseEventsFromJson_mapsFieldsCorrectly() throws Exception {
+        String json = "{\"events\":[{\"id\":\"evt1\",\"name\":\"Team A vs Team B\",\"startTime\":\"2025-08-14T20:00:00\",\"markets\":[{\"id\":\"mkt1\",\"name\":\"Match Winner\",\"selections\":[{\"id\":\"sel1\",\"name\":\"Team A\",\"odds\":1.5},{\"id\":\"sel2\",\"name\":\"Draw\",\"odds\":3.4},{\"id\":\"sel3\",\"name\":\"Team B\",\"odds\":2.8}]}]}]}";
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode node = mapper.readTree(json);
+
+        BetanoScraperService service = new BetanoScraperService(new ProxyConfig(), mapper, new UserAgentRotator());
+
+        List<BettingEvent> events = service.parseEventsFromJson(node, "evt1");
+
+        assertEquals(1, events.size());
+        BettingEvent event = events.get(0);
+        assertEquals("evt1", event.getEventId());
+        assertEquals("Team A vs Team B", event.getMatchName());
+        assertEquals(1, event.getMarkets().size());
+        assertEquals("mkt1", event.getMarkets().get(0).getMarketId());
+        assertEquals(3, event.getMarkets().get(0).getSelections().size());
+        assertEquals("sel1", event.getMarkets().get(0).getSelections().get(0).getSelectionId());
+        assertEquals(1.5, event.getMarkets().get(0).getSelections().get(0).getOdds(), 0.0001);
+    }
+}


### PR DESCRIPTION
## Summary
- broaden Betano API interception to match offer, events and betting endpoints and log parsed results
- map event, market and selection IDs plus odds in `parseEventsFromJson`
- add unit test to verify parsing of Betano JSON structure

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_689e40a78b0c8323a83f680e78e7b8d2